### PR TITLE
Allow InputInterface and OutputInterface as special parameters

### DIFF
--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -11,6 +11,8 @@ class AnnotationCommandFactory
 {
     protected $specialParameterClasses = [
         Command::class => ['getCommandReference'],
+        InputInterface::class => ['getInputReference'],
+        OutputInterface::class => ['getOutputReference'],
     ];
 
     public function __construct($specialParameterClasses = [])

--- a/tests/src/TestCommandFile.php
+++ b/tests/src/TestCommandFile.php
@@ -2,6 +2,8 @@
 namespace Consolidation\TestUtils;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class TestCommandFile
 {
@@ -84,5 +86,16 @@ class TestCommandFile
     {
         $formatter = $command->getHelperSet()->get('formatter');
         return $formatter->formatSection('test', $one);
+    }
+
+    public function testIo(InputInterface $input, OutputInterface $output, $one)
+    {
+        if (!$input instanceof InputInterface) {
+            throw new \RuntimeException('$input is not an InputInterface');
+        }
+        if (!$output instanceof OutputInterface) {
+            throw new \RuntimeException('$output is not an OutputInterface');
+        }
+        return $one;
     }
 }

--- a/tests/testAnnotationCommandFactory.php
+++ b/tests/testAnnotationCommandFactory.php
@@ -2,6 +2,8 @@
 namespace Consolidation\AnnotationCommand;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Application;
@@ -81,6 +83,21 @@ class AnnotationCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $input = new StringInput('test:command Message');
         $this->assertRunCommandViaApplicationEquals($command, $input, '[test] Message');
+    }
+
+    function testSpecialIOParameter()
+    {
+        $commandFileInstance = new \Consolidation\TestUtils\TestCommandFile();
+        $commandFactory = new AnnotationCommandFactory();
+        $commandInfo = $commandFactory->createCommandInfo($commandFileInstance, 'testIo');
+
+        $command = $commandFactory->createCommand($commandInfo, $commandFileInstance);
+
+        $this->assertInstanceOf(Command::class, $command);
+        $this->assertEquals('test:io', $command->getName());
+
+        $input = new StringInput('test:io Message');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Message');
     }
 
     function testPassthroughArray()


### PR DESCRIPTION
This allows easy passing of $input and $output, should a legacy command desire it.