### PR TITLE
Command hooks

### DIFF
--- a/src/AlterResultInterface.php
+++ b/src/AlterResultInterface.php
@@ -10,8 +10,8 @@ interface AlterResultInterface
      * After a command has executed, inspect and
      * alter the result as necessary.
      *
-     * @param mixed $result
-     * @param array $args
+     * @param  mixed $result
+     * @param  array $args
      * @return mixed $result
      */
     public function alter($result, array $args);

--- a/src/AlterResultInterface.php
+++ b/src/AlterResultInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * A StatusDeterminer maps from a result to a status exit code.
+ */
+interface AlterResultInterface
+{
+    /**
+     * After a command has executed, inspect and
+     * alter the result as necessary.
+     *
+     * @param mixed $result
+     * @param array $args
+     * @return mixed $result
+     */
+    public function alter($result, array $args);
+}

--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -46,9 +46,11 @@ class AnnotationCommandFactory
         // Ignore special functions, such as __construct and __call, and
         // accessor methods such as getFoo and setFoo, while allowing
         // set or setup.
-        $commandMethodNames = array_filter(get_class_methods($classNameOrInstance), function ($m) {
-            return !preg_match('#^(_|get[A-Z]|set[A-Z])#', $m);
-        });
+        $commandMethodNames = array_filter(
+            get_class_methods($classNameOrInstance), function ($m) {
+                return !preg_match('#^(_|get[A-Z]|set[A-Z])#', $m);
+            }
+        );
 
         foreach ($commandMethodNames as $commandMethodName) {
             $commandInfoList[] = new CommandInfo($classNameOrInstance, $commandMethodName);

--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -47,7 +47,8 @@ class AnnotationCommandFactory
         // accessor methods such as getFoo and setFoo, while allowing
         // set or setup.
         $commandMethodNames = array_filter(
-            get_class_methods($classNameOrInstance), function ($m) {
+            get_class_methods($classNameOrInstance),
+            function ($m) {
                 return !preg_match('#^(_|get[A-Z]|set[A-Z])#', $m);
             }
         );
@@ -82,7 +83,7 @@ class AnnotationCommandFactory
     {
         foreach ($commandInfoList as $commandInfo) {
             if ($commandInfo->hasAnnotation('hook')) {
-                $command = $this->registerCommandHook($commandInfo, $commandFileInstance);
+                $this->registerCommandHook($commandInfo, $commandFileInstance);
             }
         }
     }

--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -15,9 +15,22 @@ class AnnotationCommandFactory
         OutputInterface::class => ['getOutputReference'],
     ];
 
+    protected $commandProcessor;
+
     public function __construct($specialParameterClasses = [])
     {
         $this->specialParameterClasses += $specialParameterClasses;
+        $this->commandProcessor = new CommandProcessor(new HookManager());
+    }
+
+    public function setCommandProcessor($commandProcessor)
+    {
+        $this->commandProcessor = $commandProcessor;
+    }
+
+    public function commandProcessor()
+    {
+        return $this->commandProcessor;
     }
 
     public function createCommandsFromClass($commandFileInstance)
@@ -64,7 +77,7 @@ class AnnotationCommandFactory
     public function createCommand(CommandInfo $commandInfo, $commandFileInstance)
     {
         $commandCallback = [$commandFileInstance, $commandInfo->getMethodName()];
-        $command = new AnnotationCommand($commandInfo->getName(), $commandCallback);
+        $command = new AnnotationCommand($commandInfo->getName(), $commandCallback, $this->commandProcessor);
         $this->setCommandInfo($command, $commandInfo);
         $this->setCommandArguments($command, $commandInfo);
         $this->setCommandOptions($command, $commandInfo);

--- a/src/CommandError.php
+++ b/src/CommandError.php
@@ -3,6 +3,9 @@ namespace Consolidation\AnnotationCommand;
 
 class CommandError implements ExitCodeInterface, OutputDataInterface
 {
+    protected $message;
+    protected $exitCode;
+
     public function __construct($message = null, $exitCode = 1)
     {
         $this->message = $message;

--- a/src/CommandError.php
+++ b/src/CommandError.php
@@ -1,0 +1,20 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+class CommandError implements ExitCodeInterface, OutputDataInterface
+{
+    public function __construct($message = null, $exitCode = 1)
+    {
+        $this->message = $message;
+        $this->exitCode = $exitCode;
+    }
+    public function getExitCode()
+    {
+        return $this->exitCode;
+    }
+
+    public function getOutputData()
+    {
+        return $this->message;
+    }
+}

--- a/src/CommandInfo.php
+++ b/src/CommandInfo.php
@@ -234,7 +234,7 @@ class CommandInfo
 
     public function getAnnotation($annotation)
     {
-        // hasAnnotation runs $this->parseDocBlock()
+        // hasAnnotation parses the docblock
         if (!$this->hasAnnotation($annotation)) {
             return null;
         }

--- a/src/CommandInfo.php
+++ b/src/CommandInfo.php
@@ -232,13 +232,19 @@ class CommandInfo
         return array_keys($arr) !== range(0, count($arr) - 1);
     }
 
-    protected function getAnnotation($annotation)
+    public function getAnnotation($annotation)
     {
-        $this->parseDocBlock();
-        if (!array_key_exists($annotation, $this->otherAnnotations)) {
+        // hasAnnotation runs $this->parseDocBlock()
+        if (!$this->hasAnnotation($annotation)) {
             return null;
         }
         return $this->otherAnnotations[$annotation];
+    }
+
+    public function hasAnnotation($annotation)
+    {
+        $this->parseDocBlock();
+        return array_key_exists($annotation, $this->otherAnnotations);
     }
 
     protected function convertName($camel)

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -30,42 +30,42 @@ class CommandProcessor
 
     public function setValidator($validator)
     {
-        $this->globalHooks[ARGUMENT_VALIDATOR][] = $validator;
+        $this->globalHooks[self::ARGUMENT_VALIDATOR][] = $validator;
     }
 
     public function setStatusDeterminer($statusDeterminer)
     {
-        $this->globalHooks[STATUS_DETERMINER][] = $statusDeterminer;
+        $this->globalHooks[self::STATUS_DETERMINER][] = $statusDeterminer;
     }
 
     public function setAlterResultHook($resultProcessor)
     {
-        $this->globalHooks[ALTER_RESULT][] = $resultProcessor;
+        $this->globalHooks[self::ALTER_RESULT][] = $resultProcessor;
     }
 
     public function getOutputExtractor($extractor)
     {
-        $this->globalHooks[EXTRACT_OUTPUT][] = $extractor;
+        $this->globalHooks[self::EXTRACT_OUTPUT][] = $extractor;
     }
 
     public function getValidators($name)
     {
-        return $this->getHooks($name, ARGUMENT_VALIDATOR);
+        return $this->getHooks($name, self::ARGUMENT_VALIDATOR);
     }
 
     public function getStatusDeterminers($name)
     {
-        return $this->getHooks($name, STATUS_DETERMINER);
+        return $this->getHooks($name, self::STATUS_DETERMINER);
     }
 
     public function getAlterResultHooks($name)
     {
-        return $this->getHooks($name, ALTER_RESULT);
+        return $this->getHooks($name, self::ALTER_RESULT);
     }
 
     public function getOutputExtractors($name)
     {
-        return $this->getHooks($name, EXTRACT_OUTPUT);
+        return $this->getHooks($name, self::EXTRACT_OUTPUT);
     }
 
     protected function getHooks($name, $hook)

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -74,7 +74,7 @@ class CommandProcessor
         foreach (['pre-', '', 'post-'] as $stage) {
             $hooks = array_merge($hooks, $this->hookManager->get($name, "$stage$hook"));
         }
-        if (isset($this->$globalHooks[$hook])) {
+        if (isset($this->globalHooks[$hook])) {
             $hooks = array_merge($hooks, $this->globalHooks[$hook]);
         }
         return $hooks;
@@ -108,6 +108,7 @@ class CommandProcessor
     {
         $validators = $this->getValidators($name);
         foreach ($validators as $validator) {
+            $validated = null;
             if ($validator instanceof ValidatorInterface) {
                 $validated = $validator->validate($args);
             }
@@ -121,7 +122,7 @@ class CommandProcessor
                 $args = $validated;
             }
         }
-        return $validated;
+        return $args;
     }
 
     protected function handleResult($name, $result, $output)
@@ -180,7 +181,7 @@ class CommandProcessor
         $processors = $this->getAlterResultHooks($name);
         foreach ($processors as $processor) {
             if ($processor instanceof AlterResultInterface) {
-                $result = $processor->process($result, $args);
+                $result = $processor->alter($result, $args);
             }
             if (is_callable($processor)) {
                 $result = $processor($result, $args);

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -1,0 +1,284 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Process a command, including hooks and other callbacks
+ */
+class CommandProcessor
+{
+    protected $hookManager;
+    protected $globalHooks = [];
+
+    const ARGUMENT_VALIDATOR = 'validate';
+    const ALTER_RESULT = 'alter';
+    const STATUS_DETERMINER = 'status';
+    const EXTRACT_OUTPUT = 'extract';
+
+    public function __construct($hookManager)
+    {
+        $this->hookManager = $hookManager;
+    }
+
+    public function hookManager()
+    {
+        return $this->hookManager;
+    }
+
+    public function setValidator($validator)
+    {
+        $this->globalHooks[ARGUMENT_VALIDATOR][] = $validator;
+    }
+
+    public function setStatusDeterminer($statusDeterminer)
+    {
+        $this->globalHooks[STATUS_DETERMINER][] = $statusDeterminer;
+    }
+
+    public function setAlterResultHook($resultProcessor)
+    {
+        $this->globalHooks[ALTER_RESULT][] = $resultProcessor;
+    }
+
+    public function getOutputExtractor($extractor)
+    {
+        $this->globalHooks[EXTRACT_OUTPUT][] = $extractor;
+    }
+
+    public function getValidators($name)
+    {
+        return $this->getHooks($name, ARGUMENT_VALIDATOR);
+    }
+
+    public function getStatusDeterminers($name)
+    {
+        return $this->getHooks($name, STATUS_DETERMINER);
+    }
+
+    public function getAlterResultHooks($name)
+    {
+        return $this->getHooks($name, ALTER_RESULT);
+    }
+
+    public function getOutputExtractors($name)
+    {
+        return $this->getHooks($name, EXTRACT_OUTPUT);
+    }
+
+    protected function getHooks($name, $hook)
+    {
+        $hooks = [];
+        foreach (['pre-', '', 'post-'] as $stage) {
+            $hooks = array_merge($hooks, $this->hookManager->get($name, "$stage$hook"));
+        }
+        if (isset($this->$globalHooks[$hook])) {
+            $hooks = array_merge($hooks, $this->globalHooks[$hook]);
+        }
+        return $hooks;
+    }
+
+    public function process($name, $commandCallback, $specialParameters, $args, $output)
+    {
+        // Validate and change the command arguments as needed
+        $validated = $this->validateArguments($name, $args);
+
+        // Any non-array object returned signals a validation error.
+        if (is_object($validated)) {
+            return $this->handleResult($name, $validated, $output);
+        }
+        // If an array is returned, then the validation results replace
+        // the arguments.
+        if (is_array($validated)) {
+            $args = $validated;
+        }
+
+        // Run command
+        $result = $this->runCommandCallback($commandCallback, $specialParameters, $args);
+
+        // Alter results
+        $result = $this->alterResult($name, $result, $args);
+
+        return $this->handleResult($name, $result, $output);
+    }
+
+    protected function validateArguments($name, $args)
+    {
+        $validators = $this->getValidators($name);
+        foreach ($validators as $validator) {
+            if ($validator instanceof ValidatorInterface) {
+                $validated = $validator->validate($args);
+            }
+            if (is_callable($validator)) {
+                $validated = $validator($args);
+            }
+            if (is_object($validated)) {
+                return $validated;
+            }
+            if (is_array($validated)) {
+                $args = $validated;
+            }
+        }
+        return $validated;
+    }
+
+    protected function handleResult($name, $result, $output)
+    {
+        // Determine status value
+        // If the result (post-processing) is an object that
+        // implements ExitCodeInterface, then we will ask it
+        // to give us the status code. Otherwise, we assume success.
+        $status = $this->determineStatusCode($name, $result);
+        if (is_integer($result) && !isset($status)) {
+            $status = $result;
+            $result = null;
+        }
+
+        // TODO:  If status is non-zero, call rollback hooks
+        // (unless we can just rely on Collection rollbacks)
+
+        // Extract structured output from result
+        $structuredOutput = $this->extractOutput($name, $result);
+
+        // Format structured output into printable text
+        $outputText = $this->formatCommandResults($structuredOutput);
+
+        // Output the result text
+        if (isset($outputText)) {
+            $this->writeCommandOutput($outputText, $output);
+        }
+
+        // Return appropriate status code
+        return $this->interpretStatusCode($status);
+    }
+
+    /**
+     * Run the main command callback
+     */
+    protected function runCommandCallback($commandCallback, $specialParameters, $args)
+    {
+        $result = false;
+        try {
+            $args = array_merge($specialParameters, $args);
+            $result = call_user_func_array($commandCallback, $args);
+        } catch (\Exception $e) {
+            $result = new CommandError($e->getMessage(), $e->getCode());
+        }
+        return $result;
+    }
+
+    /**
+     * Allow all of the post-process hooks to run
+     */
+    protected function alterResult($name, $result, $args)
+    {
+        // Process result and decide what to do with it.
+        // Allow client to add transformation / interpretation
+        // callbacks.
+        $processors = $this->getAlterResultHooks($name);
+        foreach ($processors as $processor) {
+            if ($processor instanceof AlterResultInterface) {
+                $result = $processor->process($result, $args);
+            }
+            if (is_callable($processor)) {
+                $result = $processor($result, $args);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Call all status determiners, and see if any of them
+     * know how to convert to a status code.
+     */
+    protected function determineStatusCode($name, $result)
+    {
+        // If the result (post-processing) is an object that
+        // implements ExitCodeInterface, then we will ask it
+        // to give us the status code.
+        if ($result instanceof ExitCodeInterface) {
+            return $result->getExitCode();
+        }
+
+        // If the result does not implement ExitCodeInterface,
+        // then we'll see if there is a determiner that can
+        // extract a status code from the result.
+        $determiners = $this->getStatusDeterminers($name);
+        foreach ($determiners as $determiner) {
+            $status = null;
+            if ($determiner instanceof StatusDeterminerInterface) {
+                $status = $determiner->determineStatusCode($result);
+            }
+            if (is_callable($determiner)) {
+                $status = $determiner($result);
+            }
+            if (isset($status)) {
+                return $status;
+            }
+        }
+    }
+
+    /**
+     * Convert the result object to printable output in
+     * structured form.
+     */
+    protected function extractOutput($name, $result)
+    {
+        if ($result instanceof OutputDataInterface) {
+            return $result->getOutputData();
+        }
+
+        $extractors = $this->getOutputExtractors($name);
+        foreach ($extractors as $extractor) {
+            $structuredOutput = null;
+            if ($extractor instanceof ExtractOutputInterface) {
+                $structuredOutput = $extractor->extractOutput($result);
+            }
+            if (is_callable($extractor)) {
+                $structuredOutput = $extractor($result);
+            }
+            if (isset($structuredOutput)) {
+                return $structuredOutput;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert the structured output into a formatted
+     * string for printing.
+     */
+    protected function formatCommandResults($structuredOutput)
+    {
+        $outputText = $structuredOutput;
+
+        return $outputText;
+    }
+
+    /**
+     * If the result object is a string, then print it.
+     */
+    protected function writeCommandOutput($outputText, OutputInterface $output)
+    {
+        // If $res is a string, then print it.
+        if (is_string($outputText)) {
+            $output->writeln($outputText);
+        }
+    }
+
+    /**
+     * If a status code was set, then return it; otherwise,
+     * presume success.
+     */
+    protected function interpretStatusCode($status)
+    {
+        if (isset($status)) {
+            return $status;
+        }
+        return 0;
+    }
+}

--- a/src/ExtractOutputInterface.php
+++ b/src/ExtractOutputInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * Extract Output hooks are used to select the particular
+ * data elements of the result that should be printed as
+ * the command output -- perhaps after being formatted by
+ * a formatter.
+ */
+interface ExtractOutputInterface
+{
+    public function extractOutput($result);
+}

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -19,8 +19,8 @@ class HookManager
     /**
      * Add a hook
      *
-     * @param string $name The name of the command to hook
-     * @param string $hook The name of the hook to add
+     * @param string   $name     The name of the command to hook
+     * @param string   $hook     The name of the hook to add
      * @param callable $callback The callback function to call
      */
     public function add($name, $hook, callable $callback)

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -1,0 +1,43 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Manage named callback hooks
+ */
+class HookManager
+{
+    protected $hooks = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Add a hook
+     *
+     * @param string $name The name of the command to hook
+     * @param string $hook The name of the hook to add
+     * @param callable $callback The callback function to call
+     */
+    public function add($name, $hook, callable $callback)
+    {
+        $this->hooks[$name][$hook][] = $callback;
+    }
+
+    /**
+     * Get a set of hooks
+     *
+     * @return callable[]
+     */
+    public function get($name, $hook)
+    {
+        if (isset($this->hooks[$name][$hook])) {
+            return $this->hooks[$name][$hook];
+        }
+        return [];
+    }
+}

--- a/src/OutputDataInterface.php
+++ b/src/OutputDataInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * If an annotated command method returns an object that
+ * implements OutputDataInterface, then the getOutputData()
+ * method is used to fetch the output to print from the
+ * result object.
+ */
+interface OutputDataInterface
+{
+    public function getOutputData();
+}

--- a/src/StatusDeterminerInterface.php
+++ b/src/StatusDeterminerInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * A StatusDeterminer maps from a result to a status exit code.
+ */
+interface StatusDeterminerInterface
+{
+    /**
+     * Convert a result object into a status code, if
+     * possible. Return null if the result object is unknown.
+     *
+     * @return null|integer
+     */
+    public function determineStatusCode($result);
+}

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * Validate the arguments for the current command.
+ */
+interface ValidatorInterface
+{
+    public function validate($args);
+}

--- a/tests/src/TestCommandFile.php
+++ b/tests/src/TestCommandFile.php
@@ -4,6 +4,7 @@ namespace Consolidation\TestUtils;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Consolidation\AnnotationCommand\CommandError;
 
 class TestCommandFile
 {
@@ -97,5 +98,39 @@ class TestCommandFile
             throw new \RuntimeException('$output is not an OutputInterface');
         }
         return $one;
+    }
+
+    /**
+     * This command wraps its parameter in []; its alter hook
+     * then wraps the result in <>.
+     */
+    public function testHook($parameter)
+    {
+        return "[$parameter]";
+    }
+
+    /**
+     * Wrap the results of test:hook in <>.
+     *
+     * @hook test:hook alter
+     */
+    public function hookTestHook($result)
+    {
+        return "<$result>";
+    }
+
+    public function testHello($who)
+    {
+        return "Hello, $who.";
+    }
+
+    /**
+     * @hook test:hello validate
+     */
+    public function validateTestHello($args)
+    {
+        if ($args['who'] == 'Donald Duck') {
+            return new CommandError("I won't say hello to Donald Duck.");
+        }
     }
 }


### PR DESCRIPTION
Recognize @hook annotations to indicate that a method is a hook, not a command.