### PR TITLE
Creation listener

### DIFF
--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -33,8 +33,26 @@ class AnnotationCommandFactory
         return $this->commandProcessor;
     }
 
+    public function addListener($listener)
+    {
+        $this->listeners[] = $listener;
+    }
+
+    protected function notify($commandFileInstance)
+    {
+        foreach ($this->listeners as $listener) {
+            if ($listener instanceof CommandCreationListenerInterface) {
+                $listener->notifyCommandFileAdded($commandFileInstance);
+            }
+            if (is_callable($listener)) {
+                $listener($commandFileInstance);
+            }
+        }
+    }
+
     public function createCommandsFromClass($commandFileInstance)
     {
+        $this->notify($commandFileInstance);
         $commandInfoList = $this->getCommandInfoListFromClass($commandFileInstance);
         return $this->createCommandsFromClassInfo($commandInfoList, $commandFileInstance);
     }

--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -16,6 +16,7 @@ class AnnotationCommandFactory
     ];
 
     protected $commandProcessor;
+    protected $listeners = [];
 
     public function __construct($specialParameterClasses = [])
     {
@@ -158,6 +159,10 @@ class AnnotationCommandFactory
         $this->setCommandInfo($command, $commandInfo);
         $this->setCommandArguments($command, $commandInfo);
         $this->setCommandOptions($command, $commandInfo);
+        // Annotation commands are never bootstrap-aware, but for completeness
+        // we will notify on every created command, as some clients may wish to
+        // use this notification for some other purpose.
+        $this->notify($command);
         return $command;
     }
 

--- a/src/CommandCreationListenerInterface.php
+++ b/src/CommandCreationListenerInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * Validate the arguments for the current command.
+ */
+interface CommandCreationListenerInterface
+{
+    public function notifyCommandFileAdded($command);
+}

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -199,7 +199,7 @@ class CommandProcessor
         OutputInterface $output
     ) {
         // If there is a formatter, use it.
-        if ($formatter) {
+        if (isset($outputText) && $formatter) {
             $formatter->write($outputText, $options, $output);
             return;
         }


### PR DESCRIPTION
The creation listener is utilized by the bootstrap manager, to give it an opportunity to do dependency injection of the bootstrap object on bootstrap-aware commands. This is only necessary if this is not already being injected via dependency injection inflectors.