### PR TITLE
Process hook

### DIFF
--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -158,6 +158,10 @@ class AnnotationCommandFactory
         $this->setCommandInfo($command, $commandInfo);
         $this->setCommandArguments($command, $commandInfo);
         $this->setCommandOptions($command, $commandInfo);
+        // Annotation commands are never bootstrap-aware, but for completeness
+        // we will notify on every created command, as some clients may wish to
+        // use this notification for some other purpose.
+        $this->notify($command);
         return $command;
     }
 

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -27,9 +27,9 @@ class HookManager
      *
      * @param string   $name     The name of the command to hook
      * @param string   $hook     The name of the hook to add
-     * @param callable $callback The callback function to call
+     * @param mixed $callback The callback function to call
      */
-    public function add($name, $hook, callable $callback)
+    public function add($name, $hook, $callback)
     {
         $this->hooks[$name][$hook][] = $callback;
     }

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -13,6 +13,7 @@ class HookManager
     protected $hooks = [];
 
     const ARGUMENT_VALIDATOR = 'validate';
+    const PROCESS_RESULT = 'process';
     const ALTER_RESULT = 'alter';
     const STATUS_DETERMINER = 'status';
     const EXTRACT_OUTPUT = 'extract';
@@ -73,7 +74,7 @@ class HookManager
         // Process result and decide what to do with it.
         // Allow client to add transformation / interpretation
         // callbacks.
-        $alterers = $this->getAlterResultHooks($names);
+        $alterers = $this->getProcessAndAlterResultHooks($names);
         foreach ($alterers as $alterer) {
             $result = $this->callAlterer($alterer, $result, $args);
         }
@@ -137,9 +138,12 @@ class HookManager
         return $this->getHooks($names, self::STATUS_DETERMINER);
     }
 
-    protected function getAlterResultHooks($names)
+    protected function getProcessAndAlterResultHooks($names)
     {
-        return $this->getHooks($names, self::ALTER_RESULT);
+        return array_merge(
+            $this->getHooks($names, self::PROCESS_RESULT),
+            $this->getHooks($names, self::ALTER_RESULT)
+        );
     }
 
     protected function getOutputExtractors($names)

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -221,7 +221,7 @@ class HookManager
     protected function callProcessor($processor, $result, $args)
     {
         $processed = null;
-        if ($alterer instanceof ProcessResultInterface) {
+        if ($processor instanceof ProcessResultInterface) {
             $processed = $processor->process($result, $args);
         }
         if (is_callable($processor)) {

--- a/src/ProcessResultInterface.php
+++ b/src/ProcessResultInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+/**
+ * A StatusDeterminer maps from a result to a status exit code.
+ */
+interface ProcessResultInterface
+{
+    /**
+     * After a command has executed, if the result is something
+     * that needs to be processed, e.g. a collection of tasks to
+     * run, then execute it and return the new result.
+     *
+     * @param  mixed $result Result to (potentially) be processed
+     * @param  array $args Reference to commandline arguments and options
+     *
+     * @return mixed $result
+     */
+    public function process($result, array $args);
+}


### PR DESCRIPTION
Add a new PROCESS hook. Works the same as ALTER_RESULT, but happens first. Gives clients an extra place to add hooks to convert results e.g. from a list of tasks into a result object, without mixing these hooks with result-altering hooks.