### PR TITLE
Add CommandFileDiscovery class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": ">=5.5.0",
         "psr/log": "~1.0",
         "symfony/console": "~2.5|~3.0",
+        "symfony/finder": "~2.5|~3.0",
         "phpdocumentor/reflection-docblock": "~2"
     },
     "require-dev": {

--- a/src/AnnotationCommandFactory.php
+++ b/src/AnnotationCommandFactory.php
@@ -120,13 +120,13 @@ class AnnotationCommandFactory
      *
      * If no command name is provided, then we will presume
      * that the name of this method is the same as the name
-     * of the command being hooked (in a different commandfile).
+     * of the command being hooked (in a different commandFile).
      *
      * If no hook is provided, then we will presume that ALTER_RESULT
      * is intended.
      *
      * @param CommandInfo $commandInfo Information about the command hook method.
-     * @param object $commandFileInstance An instance of the Commandfile class.
+     * @param object $commandFileInstance An instance of the CommandFile class.
      */
     public function registerCommandHook(CommandInfo $commandInfo, $commandFileInstance)
     {

--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -117,7 +117,7 @@ class CommandFileDiscovery
      */
     public function discoverNamespaced($directoryList, $baseNamespace = '')
     {
-        return $this->discover($this->convertToNamespacedList($directoryList), $baseNamespace);
+        return $this->discover($this->convertToNamespacedList((array)$directoryList), $baseNamespace);
     }
 
     /**
@@ -185,7 +185,7 @@ class CommandFileDiscovery
         $commandFiles = $this->discoverCommandFilesInLocation($directory, '== 0', $baseNamespace);
 
         // In the other search locations,
-        foreach ($this->searchLocations as $location) {
+        foreach ($this->searchLocations as $key => $location) {
             $itemsNamespace = $this->joinNamespace([$baseNamespace, $key]);
             $commandFiles = array_merge(
                 $commandFiles,
@@ -294,7 +294,7 @@ class CommandFileDiscovery
      * Simple wrapper around implode and array_filter.
      *
      * @param string $delimiter
-     * @param string $parts
+     * @param array $parts
      * @param callable $filterFunction
      */
     protected function joinParts($delimiter, $parts, $filterFunction)

--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -1,0 +1,307 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Do discovery presuming that the namespace of the command will
+ * contain the last component of the path.  This is the convention
+ * that should be used when searching for command files that are
+ * bundled with the modules of a framework.  The convention used
+ * is that the namespace for a module in a framework should start with
+ * the framework name followed by the module name.
+ *
+ * For example, if base namespace is "Drupal", then a command file in
+ * modules/default_content/src/CliTools/ExampleCommands.cpp
+ * will be in the namespace Drupal\default_content\CliTools.
+ *
+ * For global locations, the middle component of the namespace is
+ * omitted.  For example, if the base namespace is "Drupal", then
+ * a command file in __DRUPAL_ROOT__/CliTools/ExampleCommands.cpp
+ * will be in the namespace Drupal\CliTools.
+ *
+ * To discover namespaced commands in modules:
+ *
+ * $commandFiles = $discovery->discoverNamespaced($moduleList, 'Drupal');
+ *
+ * To discover global commands:
+ *
+ * $commandFiles = $discovery->discover($drupalRoot, 'Drupal');
+ */
+class CommandFileDiscovery
+{
+    protected $excludeList;
+    protected $searchLocations;
+    protected $searchPattern = '*Commands.php';
+
+    public function __construct()
+    {
+        $this->excludeList = ['Exclude'];
+        $this->searchLocations = [
+            'CliTools',
+            'src/CliTools',
+        ];
+    }
+
+    /**
+     * Set the list of excludes to add to the finder, replacing
+     * whatever was there before.
+     *
+     * @param array $excludeList The list of directory names to skip when
+     *   searching for command files.
+     */
+    public function setExcludeList($excludeList)
+    {
+        $this->excludeList = $excludeList;
+        return $this;
+    }
+
+    /**
+     * Add one more location to the exclude list.
+     *
+     * @param string $exclude One directory name to skip when searching
+     *   for command files.
+     */
+    public function addExclude($exclude)
+    {
+        $this->excludeList[] = $exclude;
+        return $this;
+    }
+
+    /**
+     * Set the list of search locations to examine in each directory where
+     * command files may be found.  This replaces whatever was there before.
+     *
+     * @param array $searchLocations The list of locations to search for command files.
+     */
+    public function setSearchLocations($searchLocations)
+    {
+        $this->searchLocations = $searchLocations;
+        return $this;
+    }
+
+    /**
+     * Add one more location to the search location list.
+     *
+     * @param string $location One more relative path to search
+     *   for command files.
+     */
+    public function addSearchLocation($location)
+    {
+        $this->searchLocations[] = $location;
+        return $this;
+    }
+
+    /**
+     * Specify the pattern / regex used by the finder to search for
+     * command files.
+     */
+    public function setSearchPattern($searchPattern)
+    {
+        $this->searchPattern = $searchPattern;
+        return $this;
+    }
+
+    /**
+     * Given a list of directories, e.g. Drupal modules like:
+     *
+     *    core/modules/block
+     *    core/modules/dblog
+     *    modules/default_content
+     *
+     * Discover command files in any of these locations.
+     *
+     * @param string|string[] $directoryList Places to search for commands.
+     *
+     * @return array
+     */
+    public function discoverNamespaced($directoryList, $baseNamespace = '')
+    {
+        return $this->discover($this->convertToNamespacedList($directoryList), $baseNamespace);
+    }
+
+    /**
+     * Given a simple list containing paths to directories, where
+     * the last component of the path should appear in the namespace,
+     * after the base namespace, this function will return an
+     * associative array mapping the path's basename (e.g. the module
+     * name) to the directory path.
+     *
+     * Module names must be unique.
+     *
+     * @param string[] $directoryList A list of module locations
+     *
+     * @return array
+     */
+    public function convertToNamespacedList($directoryList)
+    {
+        $namespacedArray = [];
+        foreach ((array)$directoryList as $directory) {
+            $namespacedArray[basename($directory)] = $directory;
+        }
+        return $namespacedArray;
+    }
+
+    /**
+     * Search for command files in the specified locations. This is the function that
+     * should be used for all locations that are NOT modules of a framework.
+     *
+     * @param string|string[] $directoryList Places to search for commands.
+     * @return array
+     */
+    public function discover($directoryList, $baseNamespace = '')
+    {
+        $commandFiles = [];
+        foreach ((array)$directoryList as $key => $directory) {
+            $itemsNamespace = $this->joinNamespace([$baseNamespace, $key]);
+            $commandFiles = array_merge(
+                $commandFiles,
+                $this->discoverCommandFiles($directory, $itemsNamespace)
+            );
+        }
+        return $commandFiles;
+    }
+
+    /**
+     * Search for command files in specific locations within a single directory.
+     *
+     * In each location, we will accept only a few places where command files
+     * can be found. This will reduce the need to search through many unrelated
+     * files.
+     *
+     * The valid search locations include:
+     *
+     *    .
+     *    CliTools
+     *    src/CliTools
+     *
+     * The pattern we will look for is any file whose name ends in 'Commands.php'.
+     * A list of paths to found files will be returned.
+     */
+    protected function discoverCommandFiles($directory, $baseNamespace)
+    {
+        // In the search location itself, we will search for command files
+        // immediately inside the directory only.
+        $commandFiles = $this->discoverCommandFilesInLocation($directory, '== 0', $baseNamespace);
+
+        // In the other search locations,
+        foreach ($this->searchLocations as $location) {
+            $itemsNamespace = $this->joinNamespace([$baseNamespace, $key]);
+            $commandFiles = array_merge(
+                $commandFiles,
+                $this->discoverCommandFilesInLocation("$directory/$location", '< 2', $itemsNamespace)
+            );
+        }
+        return $commandFiles;
+    }
+
+    /**
+     * Search for command files in just one particular location.  Returns
+     * an associative array mapping from the pathname of the file to the
+     * classname that it contains.  The pathname may be ignored if the search
+     * location is included in the autoloader.
+     *
+     * @param string $directory The location to search
+     * @param string $depth How deep to search (e.g. '== 0' or '< 2')
+     * @param string $baseNamespace Namespace to prepend to each classname
+     *
+     * @return array
+     */
+    protected function discoverCommandFilesInLocation($directory, $depth, $baseNamespace)
+    {
+        if (!is_dir($directory)) {
+            return [];
+        }
+        $finder = $this->createFinder($directory, $depth);
+
+        $commands = [];
+        foreach ($finder as $file) {
+            $relativeNamespaceAndClassname = str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                $file->getRelativePathname()
+            );
+            $classname = $this->joinNamespace([$baseNamespace, $relativeNamespaceAndClassname]);
+            $commands[$classname] = $this->joinPaths([$directory, $file->getRelativePathname()]);
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Create a Finder object for use in searching a particular directory
+     * location.
+     *
+     * @param string $directory The location to search
+     * @param string $depth The depth limitation
+     *
+     * @return Finder
+     */
+    protected function createFinder($directory, $depth)
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name($this->searchPattern)
+            ->in($directory)
+            ->depth($depth);
+
+        foreach ($this->excludeList as $item) {
+            $finder->exclude($item);
+        }
+
+        return $finder;
+    }
+
+    /**
+     * Combine the items of the provied array into a backslash-separated
+     * namespace string.  Empty and numeric items are omitted.
+     *
+     * @param array $namespaceParts List of components of a namespace
+     *
+     * @return string
+     */
+    protected function joinNamespace(array $namespaceParts)
+    {
+        return $this->joinParts(
+            '\\',
+            $namespaceParts,
+            function ($item) {
+                return !is_numeric($item) && !empty($item);
+            }
+        );
+    }
+
+    /**
+     * Combine the items of the provied array into a slash-separated
+     * pathname.  Empty items are omitted.
+     *
+     * @param array $pathParts List of components of a path
+     *
+     * @return string
+     */
+    protected function joinPaths(array $pathParts)
+    {
+        return $this->joinParts(
+            '/',
+            $pathParts,
+            function ($item) {
+                return !empty($item);
+            }
+        );
+    }
+
+    /**
+     * Simple wrapper around implode and array_filter.
+     *
+     * @param string $delimiter
+     * @param string $parts
+     * @param callable $filterFunction
+     */
+    protected function joinParts($delimiter, $parts, $filterFunction)
+    {
+        return implode(
+            $delimiter,
+            array_filter($parts, $filterFunction)
+        );
+    }
+}

--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -222,7 +222,8 @@ class CommandFileDiscovery
                 $file->getRelativePathname()
             );
             $classname = $this->joinNamespace([$baseNamespace, $relativeNamespaceAndClassname]);
-            $commands[$classname] = $this->joinPaths([$directory, $file->getRelativePathname()]);
+            $commandFilePath = $this->joinPaths([$directory, $file->getRelativePathname()]);
+            $commands[$commandFilePath] = $classname;
         }
 
         return $commands;

--- a/tests/src/TestCommandFile.php
+++ b/tests/src/TestCommandFile.php
@@ -6,6 +6,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\AnnotationCommand\CommandError;
 
+/**
+ * Test file used in the Annotation Factory tests.  It is also
+ * discovered in the testCommandDiscovery() test.
+ *
+ * The testCommandDiscovery test search base is the 'src' directory;
+ * any command files located immediately inside the search base are
+ * eligible for discovery, and will be included in the search results.
+ */
 class TestCommandFile
 {
     protected $state;

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -1,6 +1,13 @@
 <?php
 namespace Consolidation\TestUtils\alpha;
 
+/**
+ * Test file used in the testCommandDiscovery() test.
+ *
+ * This commandfile is found by the test.  The test search base is the
+ * 'src' directory, and 'alpha' is one of the search directories available
+ * for searching.
+ */
 class AlphaCommandFile
 {
 

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -1,0 +1,7 @@
+<?php
+namespace Consolidation\TestUtils\alpha;
+
+class AlphaCommandFile
+{
+
+}

--- a/tests/src/alpha/Exclude/ExcludedCommandFile.php
+++ b/tests/src/alpha/Exclude/ExcludedCommandFile.php
@@ -1,6 +1,13 @@
 <?php
 namespace Consolidation\TestUtils\alpha\Exclude;
 
+/**
+ * Test file used in the testCommandDiscovery() test.
+ *
+ * This commandfile is NOT found by the test.  It is in a searched
+ * location (@see Consolidation\TestUtils\alpha\Exclude\IncludedCommandFile),
+ * but it is in a folder named 'Exclude', which is excluded form search.
+ */
 class ExcludedCommandFile
 {
 

--- a/tests/src/alpha/Exclude/ExcludedCommandFile.php
+++ b/tests/src/alpha/Exclude/ExcludedCommandFile.php
@@ -1,0 +1,7 @@
+<?php
+namespace Consolidation\TestUtils\alpha\Exclude;
+
+class ExcludedCommandFile
+{
+
+}

--- a/tests/src/alpha/Include/IncludedCommandFile.php
+++ b/tests/src/alpha/Include/IncludedCommandFile.php
@@ -1,0 +1,7 @@
+<?php
+namespace Consolidation\TestUtils\alpha\Include;
+
+class IncludedCommandFile
+{
+
+}

--- a/tests/src/alpha/Include/IncludedCommandFile.php
+++ b/tests/src/alpha/Include/IncludedCommandFile.php
@@ -1,6 +1,15 @@
 <?php
 namespace Consolidation\TestUtils\alpha\Include;
 
+/**
+ * Test file used in the testCommandDiscovery() test.
+ *
+ * This commandfile is found by the test.  The test search base is the
+ * 'src' directory, and 'alpha' is one of the search directories available
+ * for searching.  Directories such as this in the search locations list
+ * are searched deeply (to a depth of two), so command files may be
+ * organized into sub-namespaces, if desired.
+ */
 class IncludedCommandFile
 {
 

--- a/tests/src/beta/BetaCommandFile.php
+++ b/tests/src/beta/BetaCommandFile.php
@@ -1,0 +1,14 @@
+<?php
+namespace Consolidation\TestUtils\beta;
+
+/**
+ * Test file used in the testCommandDiscovery() test.
+ *
+ * This commandfile is found by the test.  The test search base is the
+ * 'src' directory, but 'beta' is NOT one of the search directories available
+ * for searching, so nothing in this folder will be examined.
+ */
+class BetaCommandFile
+{
+
+}

--- a/tests/src/beta/IgnoredCommandFile.php
+++ b/tests/src/beta/IgnoredCommandFile.php
@@ -1,0 +1,7 @@
+<?php
+namespace Consolidation\TestUtils\beta;
+
+class BetaCommandFile
+{
+
+}

--- a/tests/src/beta/IgnoredCommandFile.php
+++ b/tests/src/beta/IgnoredCommandFile.php
@@ -1,7 +1,0 @@
-<?php
-namespace Consolidation\TestUtils\beta;
-
-class BetaCommandFile
-{
-
-}

--- a/tests/testCommandFileDiscovery.php
+++ b/tests/testCommandFileDiscovery.php
@@ -11,15 +11,28 @@ class CommandFileDiscoveryTests extends \PHPUnit_Framework_TestCase
           ->setSearchLocations(['alpha']);
 
         chdir(__DIR__);
-        $commandFiles = $discovery->discover('src');
+        $commandFiles = $discovery->discoverNamespaced('src', 'Consolidation\TestUtils');
+
+        $commandFilePaths = array_keys($commandFiles);
+        $commandFileNamespaces = array_values($commandFiles);
 
         // Ensure that the command files that we expected to
         // find were all found.
-        $this->assertContains('src/TestCommandFile.php', $commandFiles);
-        $this->assertContains('src/alpha/AlphaCommandFile.php', $commandFiles);
-        $this->assertContains('src/alpha/Include/IncludedCommandFile.php', $commandFiles);
+        $this->assertContains('src/TestCommandFile.php', $commandFilePaths);
+        $this->assertContains('src/alpha/AlphaCommandFile.php', $commandFilePaths);
+        $this->assertContains('src/alpha/Include/IncludedCommandFile.php', $commandFilePaths);
 
         // Make sure that there are no additional items found.
-        $this->assertEquals(3, count($commandFiles));
+        $this->assertEquals(3, count($commandFilePaths));
+
+        // Ensure that the command file namespaces that we expected
+        // to be generated all match.
+        $this->assertContains('Consolidation\TestUtils\src\TestCommandFile', $commandFileNamespaces);
+        $this->assertContains('Consolidation\TestUtils\src\AlphaCommandFile', $commandFileNamespaces);
+        $this->assertContains('Consolidation\TestUtils\src\Include\IncludedCommandFile', $commandFileNamespaces);
+
+        // We do not need to test for additional namespace items, because we
+        // know that the length of the array_keys must be the same as the
+        // length of the array_values.
     }
 }

--- a/tests/testCommandFileDiscovery.php
+++ b/tests/testCommandFileDiscovery.php
@@ -1,0 +1,25 @@
+<?php
+namespace Consolidation\AnnotationCommand;
+
+class CommandFileDiscoveryTests extends \PHPUnit_Framework_TestCase
+{
+    function testCommandDiscovery()
+    {
+        $discovery = new CommandFileDiscovery();
+        $discovery
+          ->setSearchPattern('*CommandFile.php')
+          ->setSearchLocations(['alpha']);
+
+        chdir(__DIR__);
+        $commandFiles = $discovery->discover('src');
+
+        // Ensure that the command files that we expected to
+        // find were all found.
+        $this->assertContains('src/TestCommandFile.php', $commandFiles);
+        $this->assertContains('src/alpha/AlphaCommandFile.php', $commandFiles);
+        $this->assertContains('src/alpha/Include/IncludedCommandFile.php', $commandFiles);
+
+        // Make sure that there are no additional items found.
+        $this->assertEquals(3, count($commandFiles));
+    }
+}


### PR DESCRIPTION
Implementation of a basic discovery class. Finds named commandfiles and keeps track of what namespace they are expected to be in.